### PR TITLE
Improvements to build process for OSX build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+SHELL = bash
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S), Darwin)
+HOSTOS = osx
+else ifeq ($(UNAME_S), Linux)
+HOSTOS = linux
+else
+$(error Error! Unsupported Host Operating System!)
+endif
+
 export BUILD_TOPDIR=$(PWD)
 export STAGING_DIR=$(BUILD_TOPDIR)/tmp
 
@@ -274,7 +285,7 @@ ifdef COMPRESSED_UBOOT
 else
 	@cp $(BUILD_TOPDIR)/u-boot/u-boot.bin $(BUILD_TOPDIR)/bin/temp.bin
 endif
-	@/bin/echo -ne "\e[32m"
+	@echo -ne "\e[32m"
 ifndef CONFIG_SKIP_LOWLEVEL_INIT
 	@echo "> Preparing $(CONFIG_MAX_UBOOT_SIZE_KB)KB file filled with 0xFF..."
 	@`tr "\000" "\377" < /dev/zero | dd ibs=1k count=$(CONFIG_MAX_UBOOT_SIZE_KB) of=$(BUILD_TOPDIR)/bin/$(UBOOT_FILE_NAME)$(UBOOT_FILE_NAME_SUFFIX).bin 2> /dev/null`
@@ -290,19 +301,19 @@ endif
 	@`echo ' *'$(UBOOT_FILE_NAME)$(UBOOT_FILE_NAME_SUFFIX).bin >> $(BUILD_TOPDIR)/bin/$(UBOOT_FILE_NAME)$(UBOOT_FILE_NAME_SUFFIX).md5`
 # Do not check image size for RAM version
 ifndef CONFIG_SKIP_LOWLEVEL_INIT
-	@if [ "`wc -c < $(BUILD_TOPDIR)/bin/$(UBOOT_FILE_NAME)$(UBOOT_FILE_NAME_SUFFIX).bin`" -gt "`/bin/echo '$(CONFIG_MAX_UBOOT_SIZE_KB)*1024' | bc`" ]; then \
-			/bin/echo -e "\e[31m\n**************************************************"; \
-			/bin/echo "*     WARNING: U-BOOT IMAGE SIZE IS TOO BIG!     *"; \
-			/bin/echo -e "**************************************************"; \
+	@if [ "`wc -c < $(BUILD_TOPDIR)/bin/$(UBOOT_FILE_NAME)$(UBOOT_FILE_NAME_SUFFIX).bin`" -gt "`echo '$(CONFIG_MAX_UBOOT_SIZE_KB)*1024' | bc`" ]; then \
+			echo -e "\e[31m\n**************************************************"; \
+			echo "*     WARNING: U-BOOT IMAGE SIZE IS TOO BIG!     *"; \
+			echo -e "**************************************************"; \
 	fi;
 endif
-	@/bin/echo -ne "\e[0m"
+	@echo -ne "\e[0m"
 
 clean:
 	@cd $(BUILD_TOPDIR)/u-boot/ && $(MAKECMD) --no-print-directory distclean
 	@rm -f $(BUILD_TOPDIR)/u-boot/httpd/fsdata.c
 
 clean_all:	clean
-	@/bin/echo -e "\e[32m> Removing all binary images...\e[0m"
+	@echo -e "\e[32m> Removing all binary images...\e[0m"
 	@rm -f $(BUILD_TOPDIR)/bin/*.bin
 	@rm -f $(BUILD_TOPDIR)/bin/*.md5

--- a/README.md
+++ b/README.md
@@ -668,6 +668,24 @@ make tplink_wr703n
 
 will start building U-Boot image for **TP-Link TL-WR703N**.
 
+### Building on OS X
+
+You can build using the openwrt/lede toolchain as above under OS X as long as you install several gnu command line tools via brew. Note that bash is required to correct the usage of colorized echo output within the Makefiles (I was suprised how inconsistent FreeBSD is with Linux in this regard).
+
+```
+brew install bash coreutils gnu-sed
+```
+
+Subsequently, in addition to the toolchain being in your path, you will need to point your path as instructed by brew to the gnu binaries (only required for the build).
+
+```
+export PATH=/usr/local/opt/coreutils/libexec/gnubin:/usr/local/opt/gnu-sed/libexec/gnubin:$PATH
+```
+
+Lastly, you will need a localised (osx) build of lzma replacing the supplied ELF32 binary in the host_utils folder. I have tested with [lzma-4.32.7](http://tukaani.org/lzma/lzma-4.32.7.tar.gz) ; just run ./configure and then make and grab the executable from src/lzma.
+
+This process was tested on Yosemite and El Capitan.
+
 FAQ
 ---
 

--- a/u-boot/Makefile
+++ b/u-boot/Makefile
@@ -20,6 +20,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307 USA
 #
+SHELL = bash
 
 VERSION			= 1
 PATCHLEVEL		= 1
@@ -188,7 +189,7 @@ u-boot.bin:	u-boot
 	$(OBJCOPY) ${OBJCFLAGS} -O binary $< $@
 
 u-boot.img:	u-boot.bin
-	@/bin/echo -e "\e[32m> Preparing U-Boot image \"u-boot.img\"...\e[0m"
+	@echo -e "\e[32m> Preparing U-Boot image \"u-boot.img\"...\e[0m"
 	./tools/mkimage -A $(ARCH) -T firmware -C none \
 		-a $(TEXT_BASE) -e 0 \
 		-n $(shell sed -n -e 's/.*U_BOOT_VERSION//p' $(VERSION_FILE) | \
@@ -221,7 +222,7 @@ tuboot.bin:	System.map bootstrap.bin u-boot.lzimg
 u-boot.lzimg: $(obj)u-boot.bin System.map
 	@rm -rf u-boot.bin.lzma
 	$(LZMA) --best --keep $(obj)u-boot.bin
-	@/bin/echo -e "\e[32m> Preparing compressed U-Boot image \"u-boot.lzimg\"...\e[0m"
+	@echo -e "\e[32m> Preparing compressed U-Boot image \"u-boot.lzimg\"...\e[0m"
 	./tools/mkimage -A mips -T firmware -C lzma \
 		-a 0x$(shell grep "T _start" $(TOPDIR)/System.map | awk '{ printf "%s", $$1 }') \
 		-e 0x$(shell grep "T _start" $(TOPDIR)/System.map | awk '{ printf "%s", $$1 }') \
@@ -347,7 +348,7 @@ hornet_common_config : common_config
 	@echo "#define CONFIG_MACH_HORNET                   1" >> include/config.h
 
 wr703n_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WR703N at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WR703N at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_WR703N_V1          1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -357,7 +358,7 @@ wr703n_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 wr720n_v3_CN_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WR720N v3 CN at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WR720N v3 CN at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_WR720N_V3          1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -367,7 +368,7 @@ wr720n_v3_CN_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 wr710n_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WR710N at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WR710N at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_WR710N_V1          1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      8" >> include/config.h
@@ -377,7 +378,7 @@ wr710n_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 mr3020_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-MR3020 at:' `date`.'\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-MR3020 at:' `date`.'\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_MR3020_V1          1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -387,7 +388,7 @@ mr3020_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 mr3040_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-MR3040 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-MR3040 at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_MR3040_V1V2        1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -397,7 +398,7 @@ mr3040_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 mr10u_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-MR10U at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-MR10U at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_MR10U_V1           1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -407,7 +408,7 @@ mr10u_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 mr13u_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-MR13U at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-MR13U at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_MR13U_V1           1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -417,7 +418,7 @@ mr13u_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 wr740n_v4_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WR740N v4 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WR740N v4 at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_WR740N_V4          1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -427,7 +428,7 @@ wr740n_v4_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 mr3220_v2_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-MR3220 v2 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-MR3220 v2 at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_TPLINK_MR3220_V2          1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      4" >> include/config.h
@@ -437,7 +438,7 @@ mr3220_v2_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 dir505_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for D-Link DIR-505 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for D-Link DIR-505 at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_DLINK_DIR505_A1           1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN_ACTIVE_LOW     1" >> include/config.h
@@ -447,7 +448,7 @@ dir505_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 gs_oolite_v1_dev_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for GS-Oolite v1 with dev board at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for GS-Oolite v1 with dev board at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_GS_OOLITE_V1_DEV          1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB     16" >> include/config.h
@@ -466,7 +467,7 @@ black_swift_board_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 carambola2_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for 8devices Carambola 2 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for 8devices Carambola 2 at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_8DEVICES_CARAMBOLA2       1" >> include/config.h
 	@echo "#undef COMPRESSED_UBOOT"                        >> include/config.h
 	@echo "#define CONFIG_40MHZ_XTAL_SUPPORT            1" >> include/config.h
@@ -478,7 +479,7 @@ carambola2_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 dragino_v2_ms14_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for Dragino Dragino v2 (MS14) at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for Dragino Dragino v2 (MS14) at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_DRAGINO_V2                1" >> include/config.h
 	@echo "#undef  COMPRESSED_UBOOT"                       >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
@@ -491,7 +492,7 @@ dragino_v2_ms14_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 villagetelco_mp2_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for Village Telco Mesh Potato 2 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for Village Telco Mesh Potato 2 at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_MESH_POTATO_V2            1" >> include/config.h
 	@echo "#undef  COMPRESSED_UBOOT"                       >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
@@ -504,7 +505,7 @@ villagetelco_mp2_config : unconfig hornet_common_config
 	@./mkconfig -a ap121 mips mips ap121 ar7240 ar7240
 
 gl-inet_config : unconfig hornet_common_config
-	@/bin/echo -e '\e[32m> Configuring for GL.iNet at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for GL.iNet at:' `date` '\e[0m'
 	@echo "#define CONFIG_FOR_GL_INET                   1" >> include/config.h
 	@echo "#define CONFIG_GPIO_RESET_BTN               11" >> include/config.h
 	@echo "#define CONFIG_DEFAULT_FLASH_SIZE_IN_MB      8" >> include/config.h
@@ -517,7 +518,7 @@ wasp_common_config : common_config
 	@echo "#define CONFIG_WASP_SUPPORT                  1" >> include/config.h
 
 wdr3600_43x0_config : unconfig wasp_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WDR3600/43x0 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WDR3600/43x0 at:' `date` '\e[0m'
 	@echo "#define SOC_TYPE                QCA_AR9344_SOC" >> include/config.h
 	@echo "#define CONFIG_FOR_TPLINK_WDR3600_WDR43X0_V1 1" >> include/config.h
 	@echo "#define DDR2_32BIT_SUPPORT                   1" >> include/config.h
@@ -533,7 +534,7 @@ wdr3600_43x0_config : unconfig wasp_common_config
 	@./mkconfig -a db12x mips mips db12x ar7240 ar7240
 
 wdr3500_config : unconfig wasp_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WDR3500 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WDR3500 at:' `date` '\e[0m'
 	@echo "#define SOC_TYPE                QCA_AR9344_SOC" >> include/config.h
 	@echo "#define CONFIG_FOR_TPLINK_WDR3500_V1         1" >> include/config.h
 	@echo "#define DDR2_32BIT_SUPPORT                   1" >> include/config.h
@@ -548,7 +549,7 @@ wdr3500_config : unconfig wasp_common_config
 	@./mkconfig -a db12x mips mips db12x ar7240 ar7240
 
 mr3420_v2_config : unconfig wasp_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-MR3420 v2 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-MR3420 v2 at:' `date` '\e[0m'
 	@echo "#define SOC_TYPE                QCA_AR9341_SOC" >> include/config.h
 	@echo "#define CONFIG_FOR_TPLINK_MR3420_V2          1" >> include/config.h
 	@echo "#define CONFIG_AP123                         1" >> include/config.h
@@ -564,7 +565,7 @@ mr3420_v2_config : unconfig wasp_common_config
 	@./mkconfig -a db12x mips mips db12x ar7240 ar7240
 
 wr841n_v8_config : unconfig wasp_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WR841N/D v8 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WR841N/D v8 at:' `date` '\e[0m'
 	@echo "#define SOC_TYPE                QCA_AR9341_SOC" >> include/config.h
 	@echo "#define CONFIG_FOR_TPLINK_WR841N_V8          1" >> include/config.h
 	@echo "#define CONFIG_AP123                         1" >> include/config.h
@@ -580,7 +581,7 @@ wr841n_v8_config : unconfig wasp_common_config
 	@./mkconfig -a db12x mips mips db12x ar7240 ar7240
 
 wa830re_v2_wa801nd_v2_config : unconfig wasp_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WA830RE/TL-WA801ND v2 at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WA830RE/TL-WA801ND v2 at:' `date` '\e[0m'
 	@echo "#define SOC_TYPE                   QCA_AR9341_SOC" >> include/config.h
 	@echo "#define CONFIG_FOR_TPLINK_WA830RE_V2_WA801ND_V2 1" >> include/config.h
 	@echo "#define CONFIG_AP123                            1" >> include/config.h
@@ -600,7 +601,7 @@ ap143_common_config : common_config
 	@echo "#define CONFIG_MACH_QCA953x                  1" >> include/config.h
 
 wr820n_CN_config : unconfig ap143_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WR820N CN at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WR820N CN at:' `date` '\e[0m'
 	@echo "#define SOC_TYPE               QCA_QCA953X_SOC" >> include/config.h
 	@echo "#define CONFIG_FOR_TPLINK_WR820N_CN          1" >> include/config.h
 	@echo "#define CFG_ATHRS27_PHY                      1" >> include/config.h
@@ -614,7 +615,7 @@ wr820n_CN_config : unconfig ap143_common_config
 	@./mkconfig -a ap143 mips mips ap143 ar7240 ar7240
 
 wr802n_config : unconfig ap143_common_config
-	@/bin/echo -e '\e[32m> Configuring for TP-Link TL-WR802N at:' `date` '\e[0m'
+	@echo -e '\e[32m> Configuring for TP-Link TL-WR802N at:' `date` '\e[0m'
 	@echo "#define SOC_TYPE               QCA_QCA953X_SOC" >> include/config.h
 	@echo "#define CONFIG_FOR_TPLINK_WR802N             1" >> include/config.h
 	@echo "#define CFG_ATHRS27_PHY                      1" >> include/config.h
@@ -646,7 +647,7 @@ wr841n_v9_config : unconfig ap143_common_config
 #########################################################################
 
 clean:
-	@/bin/echo -e "\e[32m> Making $@...\e[0m"
+	@echo -e "\e[32m> Making $@...\e[0m"
 	@find . -type f \
 		\( -name 'core' -o -name '*.bak' -o -name '*~' \
 		-o -name '*.o'  -o -name '*.a' -o -name .depend \) -print \
@@ -657,7 +658,7 @@ clean:
 	@rm -f bootstrap bootstrap.bin tuboot.bin u-boot.lzimg u-boot.bin.lzma bootstrap.map
 
 clobber:	clean
-	@/bin/echo -e "\e[32m> Making $@...\e[0m"
+	@echo -e "\e[32m> Making $@...\e[0m"
 	@find . -type f \( -name .depend \
 		-o -name '*.srec' -o -name '*.bin' -o -name u-boot.img \) \
 		-print0 \


### PR DESCRIPTION
Requires updated bash and gnu coreutils, gnu-sed via brew.
Added HostOS platform sanity check (only linux and osx supported/tested)
Makefile and u-boot/Makefile forces SHELL to bash which addresses issues with cross platform "echo" and nullifies previous workaround /bin/echo (for -e and -n).
Added documentation for building on OS X