### PR TITLE
Set CAS_LATENCY/GATE_OPEN_LATENCY to (2*CL)+1 for AR933x running DDR2

### DIFF
--- a/u-boot/cpu/mips/ar7240/qca_dram.c
+++ b/u-boot/cpu/mips/ar7240/qca_dram.c
@@ -527,6 +527,11 @@ static inline void qca_dram_set_ddr_cfg(u32 mem_cas,
 
 	/* CAS should be (2 * MEM_CAS) or (2 * MEM_CAS) + 1/2/3 */
 	tmp = 2 * mem_cas;
+#if (SOC_TYPE & QCA_AR933X_SOC)
+	if(mem_type == RAM_MEMORY_TYPE_DDR2) {
+		tmp = tmp + 1;	// Use (2 * MEM_CAS) + 1 for AR933x DDR2.
+	}
+#endif
 	tmp = (tmp << QCA_DDR_CFG_CAS_3LSB_SHIFT) & QCA_DDR_CFG_CAS_3LSB_MASK;
 	if (mem_cas > 3) {
 		tmp = tmp | QCA_DDR_CFG_CAS_MSB_MASK;
@@ -624,6 +629,11 @@ static inline void qca_dram_set_ddr_cfg2(u32 mem_cas,
 
 	/* Gate open latency = 2 * MEM_CAS */
 	tmp = 2 * mem_cas;
+#if (SOC_TYPE & QCA_AR933X_SOC)
+	if(mem_type == RAM_MEMORY_TYPE_DDR2) {
+		tmp = tmp + 1;	// Use (2 * MEM_CAS) + 1 for AR933x DDR2.
+	}
+#endif	
 	tmp = (tmp << QCA_DDR_CFG2_GATE_OPEN_LATENCY_SHIFT)
 		  & QCA_DDR_CFG2_GATE_OPEN_LATENCY_MASK;
 	reg = reg & ~QCA_DDR_CFG2_GATE_OPEN_LATENCY_MASK;


### PR DESCRIPTION
Documented in https://github.com/pepe2k/u-boot_mod/commit/3527b8cc2a989e51197831eab1f941429f8ffeea

Unstable behaviour in openwrt/lede found with use of SKW72 (Skylabs) OEM AP121 reference board: -

AR9331-AL3A,
Flash = Winbond (25Q128FVSG)
Ram = Zentel DDR2 (A3R12E40CBF).

Prior to clean up in 3527b8cc2a, CAS_LATENCY and GATE_OPEN_LATENCY were set to (CL*2)+1. This commit reverts to the previous calculation by adding the extra DDR clock cycle.

This stabilised 3 out of 10 preproduction devices which exhibited critical stability issues.
