### PR TITLE
Add support for TP-LINK TL-MR22U v1 (QCA9531 based)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ $(COMMON_AR933X_TARGETS):
 	@$(call build,123,1)
 
 COMMON_ETHS27_TARGETS = \
+	tp-link_tl-mr22u_v1 \
 	tp-link_tl-mr3420_v2 \
 	tp-link_tl-mr3420_v3 \
 	tp-link_tl-wa801nd_v2 \

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Currently supported devices:
   - Comfast CF-E520N/CF-E530N
   - P&W CPE505N
   - P&W R602N
+  - TP-Link TL-MR22U v1
   - TP-Link TL-MR3420 v3
   - TP-Link TL-WA850RE v2
   - TP-Link TL-WR802N
@@ -139,6 +140,7 @@ More information about supported devices:
 | P&W R602N | QCA9531 | 16 MiB | 64 MiB DDR2 | 256 KiB | R/W |
 | [TP-Link TL-MR10U v1](http://wiki.openwrt.org/toh/tp-link/tl-mr10u) | AR9331 | 4 MiB | 32 MiB DDR1 | 64 KiB, LZMA | RO |
 | [TP-Link TL-MR13U v1](http://wiki.openwrt.org/toh/tp-link/tl-mr13u) | AR9331 | 4 MiB | 32 MiB DDR1 | 64 KiB, LZMA | RO |
+| [TP-Link TL-MR22U v1](https://wiki.openwrt.org/toh/tp-link/tp-link_tl-mr22u_v1) | QCA9531 | 8 MiB | 32 MiB DDR1 | 64 KiB, LZMA | RO |
 | [TP-Link TL-MR3020 v1](http://wiki.openwrt.org/toh/tp-link/tl-mr3020) | AR9331 | 4 MiB | 32 MiB DDR1 | 64 KiB, LZMA | RO |
 | [TP-Link TL-MR3040 v1/2](http://wiki.openwrt.org/toh/tp-link/tl-mr3040) | AR9331 | 4 MiB | 32 MiB DDR1 | 64 KiB, LZMA | RO |
 | [TP-Link TL-MR3220 v2](http://wiki.openwrt.org/toh/tp-link/tl-mr3420) | AR9331 | 4 MiB | 32 MiB DDR1 | 64 KiB, LZMA | RO |

--- a/u-boot/Makefile
+++ b/u-boot/Makefile
@@ -492,6 +492,13 @@ tp-link_tl-mr13u: ar933x_common lsdk_kernel
 	@$(call define_add,CONFIG_FOR_TPLINK_MR13U_V1,1)
 	@$(MKCONFIG) -a ap121 mips mips ap121 ar7240 ar7240
 
+tp-link_tl-mr22u_v1: qca953x_common lsdk_kernel
+	@$(call config_init,TP-Link TL-MR22U v1,tl-mr22u-v1,8,12,,QCA_QCA953X_SOC)
+	@$(call define_add,CONFIG_FOR_TPLINK_MR22U_V1,1)
+	@$(call define_add,CFG_ATHRS27_PHY,1)
+	@$(call define_add,CFG_ATH_GMAC_NMACS,2)
+	@$(MKCONFIG) -a ap143 mips mips ap143 ar7240 ar7240
+
 tp-link_tl-mr3020: ar933x_common lsdk_kernel
 	@$(call config_init,TP-Link TL-MR3020,tl-mr3020,4,11,,QCA_AR933X_SOC)
 	@$(call define_add,CONFIG_FOR_TPLINK_MR3020_V1,1)

--- a/u-boot/include/configs/ap143.h
+++ b/u-boot/include/configs/ap143.h
@@ -64,6 +64,15 @@
 	#define CONFIG_QCA_GPIO_MASK_IN		GPIO17
 	#define CONFIG_QCA_GPIO_MASK_OUT_INIT_H	CONFIG_QCA_GPIO_MASK_LED_ACT_L
 
+#elif defined(CONFIG_FOR_TPLINK_MR22U_V1)
+
+	#define CONFIG_QCA_GPIO_MASK_LED_ACT_L	GPIO13
+	#define CONFIG_QCA_GPIO_MASK_OUT	GPIO11 |\
+						CONFIG_QCA_GPIO_MASK_LED_ACT_L
+	#define CONFIG_QCA_GPIO_MASK_IN		GPIO14 | GPIO16 | GPIO12
+	#define CONFIG_QCA_GPIO_MASK_OUT_INIT_H	GPIO11 |\
+						CONFIG_QCA_GPIO_MASK_LED_ACT_L
+
 #elif defined(CONFIG_FOR_TPLINK_WA850RE_V2)
 
 	#define CONFIG_QCA_GPIO_MASK_LED_ACT_L	GPIO0  | GPIO1 | GPIO2  |\
@@ -206,7 +215,8 @@
 				"rootfstype=squashfs init=/sbin/init "\
 				"mtdparts=spi0.0:256k(u-boot),64k(u-boot-env),14528k(rootfs),1472k(kernel),64k(art),16000k(firmware)"
 
-#elif defined(CONFIG_FOR_TPLINK_WR810N)
+#elif defined(CONFIG_FOR_TPLINK_MR22U_V1) ||\
+      defined(CONFIG_FOR_TPLINK_WR810N)
 
 	#define CONFIG_BOOTARGS	"console=ttyS0,115200 root=31:02 "\
 				"rootfstype=squashfs init=/sbin/init "\
@@ -253,6 +263,7 @@
     defined(CONFIG_FOR_COMFAST_CF_E320N_V2) ||\
     defined(CONFIG_FOR_COMFAST_CF_E520N)    ||\
     defined(CONFIG_FOR_COMFAST_CF_E530N)    ||\
+    defined(CONFIG_FOR_TPLINK_MR22U_V1)     ||\
     defined(CONFIG_FOR_TPLINK_MR3420_V3)    ||\
     defined(CONFIG_FOR_TPLINK_WA850RE_V2)   ||\
     defined(CONFIG_FOR_TPLINK_WR802N)       ||\
@@ -303,7 +314,8 @@
 	#define CFG_ENV_ADDR		0x9F040000
 	#define CFG_ENV_SIZE		0xFC00
 	#define CFG_ENV_SECT_SIZE	0x10000
-#elif defined(CONFIG_FOR_TPLINK_MR3420_V3)  ||\
+#elif defined(CONFIG_FOR_TPLINK_MR22U_V1)   ||\
+      defined(CONFIG_FOR_TPLINK_MR3420_V3)  ||\
       defined(CONFIG_FOR_TPLINK_WA850RE_V2) ||\
       defined(CONFIG_FOR_TPLINK_WR802N)     ||\
       defined(CONFIG_FOR_TPLINK_WR810N)     ||\
@@ -355,7 +367,8 @@
 	#define OFFSET_MAC_DATA_BLOCK		0x3c0000
 	#define OFFSET_MAC_DATA_BLOCK_LENGTH	0x010000
 	#define OFFSET_MAC_ADDRESS		0x000008
-#elif defined(CONFIG_FOR_TPLINK_MR3420_V3)  ||\
+#elif defined(CONFIG_FOR_TPLINK_MR22U_V1)   ||\
+      defined(CONFIG_FOR_TPLINK_MR3420_V3)  ||\
       defined(CONFIG_FOR_TPLINK_WR802N)     ||\
       defined(CONFIG_FOR_TPLINK_WR810N)     ||\
       defined(CONFIG_FOR_TPLINK_WR820N_CN)  ||\
@@ -417,6 +430,7 @@
     defined(CONFIG_FOR_COMFAST_CF_E320N_V2) ||\
     defined(CONFIG_FOR_COMFAST_CF_E520N)    ||\
     defined(CONFIG_FOR_COMFAST_CF_E530N)    ||\
+    defined(CONFIG_FOR_TPLINK_MR22U_V1)     ||\
     defined(CONFIG_FOR_TPLINK_MR3420_V3)    ||\
     defined(CONFIG_FOR_TPLINK_WR802N)       ||\
     defined(CONFIG_FOR_TPLINK_WR810N)       ||\
@@ -444,7 +458,8 @@
  * PLL/Clocks configuration
  * ========================
  */
-#if defined(CONFIG_FOR_TPLINK_WA850RE_V2) ||\
+#if defined(CONFIG_FOR_TPLINK_MR22U_V1)   ||\
+    defined(CONFIG_FOR_TPLINK_WA850RE_V2) ||\
     defined(CONFIG_FOR_TPLINK_WR802N)     ||\
     defined(CONFIG_FOR_TPLINK_WR820N_CN)  ||\
     defined(CONFIG_FOR_TPLINK_WR841N_V9)
@@ -457,6 +472,7 @@
     defined(CONFIG_FOR_COMFAST_CF_E320N_V2) ||\
     defined(CONFIG_FOR_COMFAST_CF_E520N)    ||\
     defined(CONFIG_FOR_COMFAST_CF_E530N)    ||\
+    defined(CONFIG_FOR_TPLINK_MR22U_V1)     ||\
     defined(CONFIG_FOR_TPLINK_WA850RE_V2)   ||\
     defined(CONFIG_FOR_TPLINK_MR3420_V3)    ||\
     defined(CONFIG_FOR_TPLINK_WR802N)       ||\


### PR DESCRIPTION
Add support for TP-LINK TL-MR22U v1 (QCA9531 based)

Reset button, netconsole and webserver recovery tested and working.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>