### PR TITLE
fix timing

### DIFF
--- a/u-boot/include/env_scripts.h
+++ b/u-boot/include/env_scripts.h
@@ -153,11 +153,11 @@
 			"echo;" \
 			"while button && itest $cnt < 0xA; do " \
 				"ledon;" \
-				"sleep 300;" \
+				"sleep 250;" \
 				"echo . \'\\\\c\';" \
-				"sleep 300;" \
+				"sleep 250;" \
 				"ledoff;" \
-				"sleep 600;" \
+				"sleep 500;" \
 				"setexpr cnt $cnt + 1;" \
 			"done;" \
 			"echo 0x$cnt seconds;" \


### PR DESCRIPTION
With current values one needs to hold reset button for approx. 10 sec to enter netconsole, reduce that to 7 sec as originally defined.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>